### PR TITLE
Add @aeorank/docusaurus — AI-visibility plugin for Docusaurus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@
 
 - [plugin-sitemap](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap) (official) - Generate a sitemap.xml file for search engines.
 - [docusaurus-plugin-structured-data](https://github.com/CoffeeCupTechWriting/docusaurus-plugin-structured-data) - Automatically generate JSON-LD structured data (schema.org) for SEO.
+- [@aeorank/docusaurus](https://github.com/vinpatel/aeorank/tree/main/packages/docusaurus) - Scores your docs site's AI visibility and generates the 9 files (llms.txt, ai.txt, CLAUDE.md, ...) that ChatGPT and Perplexity read.
 
 ### Tracking
 


### PR DESCRIPTION
Hey! Adding AEOrank's Docusaurus plugin to the SEO section since it fits alongside sitemap and structured-data — same idea, just aimed at how AI assistants (ChatGPT, Perplexity, Claude, Google AI Overviews) read your docs rather than traditional search crawlers.

The plugin scores your site 0-100 across 36 AI-visibility criteria and generates the 9 files those assistants actually look for (llms.txt, ai.txt, CLAUDE.md, and friends) straight into your build output. It's MIT-licensed and shipped under the AEOrank monorepo at https://github.com/vinpatel/aeorank.

Plugin source: https://github.com/vinpatel/aeorank/tree/main/packages/docusaurus
npm: https://www.npmjs.com/package/@aeorank/docusaurus
Project site: https://aeorank.dev

Thanks for maintaining this list!