### PR TITLE
Add docusaurus-plugin-copy-page-button to SEO section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@
 - [plugin-sitemap](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap) (official) - Generate a sitemap.xml file for search engines.
 - [docusaurus-plugin-structured-data](https://github.com/CoffeeCupTechWriting/docusaurus-plugin-structured-data) - Automatically generate JSON-LD structured data (schema.org) for SEO.
 - [@aeorank/docusaurus](https://github.com/vinpatel/aeorank/tree/main/packages/docusaurus) - Scores your docs site's AI visibility and generates the 9 files (llms.txt, ai.txt, CLAUDE.md, ...) that ChatGPT and Perplexity read.
+- [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button) - Adds a "Copy page" button that exports doc pages as clean markdown for ChatGPT, Claude, and Gemini.
 
 ### Tracking
 


### PR DESCRIPTION
Adds an entry for [docusaurus-plugin-copy-page-button](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button).

The plugin adds a "Copy page" button to the docs sidebar that exports the page as clean markdown, with one-click "Open in ChatGPT/Claude/Gemini" actions. It fits alongside the existing `@aeorank/docusaurus` entry under SEO since both target AI/LLM visibility for docs.

Around 10k installs/month and currently shipping on Ethereum execution-apis, Sui, Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, and Chronicle docs.

- Repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/

Happy to move it under Miscellaneous instead if SEO doesn't feel like the right home.