### PR TITLE
Add docusaurus-biel to Search plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,9 @@
 
 ### Search
 
-- [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel) - AI chat and search that answers questions from your documentation, with citations to the source pages.
 - [docusaurus-plugin-lunr](https://github.com/daldridge/docusaurus-plugin-lunr) - Create search index for use with Lunr.js.
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline / local search that works behind your firewall.
+- [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel) - AI chat and search that answers questions from your documentation, with citations to the source pages.
 
 ### Sidebars
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@
 
 ### Search
 
+- [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel) - AI chat and search that answers questions from your documentation, with citations to the source pages.
 - [docusaurus-plugin-lunr](https://github.com/daldridge/docusaurus-plugin-lunr) - Create search index for use with Lunr.js.
 - [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local) - Offline / local search that works behind your firewall.
 


### PR DESCRIPTION
Adds [docusaurus-biel](https://github.com/TechDocsStudio/docusaurus-biel), AI chat and search for Docusaurus sites with answers cited from your own docs. The plugin is MIT-licensed and connects to the Biel.ai service.