### PR TITLE
Add cosmos-docusaurus-theme to Themes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@
 - [theme-live-codeblock](https://docusaurus.io/docs/api/themes/@docusaurus/theme-live-codeblock) (official) - A theme for live code blocks.
 - [theme-search-algolia](https://docusaurus.io/docs/api/themes/@docusaurus/theme-search-algolia) (official) - Algolia search component.
 - [docusaurus-theme-search-typesense](https://github.com/typesense/docusaurus-theme-search-typesense) - Typesense search component.
+- [cosmos-docusaurus-theme](https://github.com/SckyzO/cosmos-docusaurus-theme) - Clean, dark-first, CSS-only theme with Void/Slate palettes, self-hosted Outfit + IBM Plex Mono, and WCAG AA colors.
 
 
 ## Contribute


### PR DESCRIPTION
Adds [cosmos-docusaurus-theme](https://github.com/SckyzO/cosmos-docusaurus-theme) under **Themes**.

A clean, dark-first, CSS-only Docusaurus 3 theme: Void (dark) / Slate (light) palettes, self-hosted Outfit + IBM Plex Mono (no CDN), WCAG AA colors, no component swizzling. [Live demo](https://sckyzo.github.io/cosmos-docusaurus-theme/) · [npm](https://www.npmjs.com/package/cosmos-docusaurus-theme).

One line added, alphabetical placement kept within the community themes.